### PR TITLE
removed ":" from a slice call

### DIFF
--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func fetchImage() string {
 	policyContext, err := signature.NewPolicyContext(policy)
 	must(err)
 
-	fmt.Printf("Fetching container %s \n", os.Args[2:])
+	fmt.Printf("Fetching container %s \n", os.Args[2])
 
 	srcRef, err := alltransports.ParseImageName(os.Args[2])
 	must(err)


### PR DESCRIPTION
Fixed line
```go
fmt.Printf("Fetching container %s \n", os.Args[2:])
```
to 
```go
fmt.Printf("Fetching container %s \n", os.Args[2])
```
so the fetching container message doesn't show the arg to run inside the container